### PR TITLE
Fixing broken images on docs

### DIFF
--- a/components/bottom-navigation-bar.md
+++ b/components/bottom-navigation-bar.md
@@ -4,7 +4,7 @@
 
 
 
-![bottomnavigationbar](.\images\bottomnavigationbar.png)
+![bottomnavigationbar](images/bottomnavigationbar.png)
 
 | Property | Options   | Description                                          |
 | -------- | --------- | ---------------------------------------------------- |

--- a/components/button.md
+++ b/components/button.md
@@ -5,7 +5,7 @@
 
 
 
-![button](.\images\button.png)
+![button](images/button.png)
 
 | Property | Options                                         | Description                                                  |
 | -------- | ----------------------------------------------- | ------------------------------------------------------------ |

--- a/components/filter-chip.md
+++ b/components/filter-chip.md
@@ -4,7 +4,7 @@
 
 > **Binding:** By default, Data set with the **Content** field in the **Properties** tab in the plugin will be applied to the *Content* property for this component.
 
-![filterchip](.\images\filterchip.png)
+![filterchip](images/filterchip.png)
 
 | Property | Options                                           | Description                                                  |
 | -------- | ------------------------------------------------- | ------------------------------------------------------------ |

--- a/components/input-chip.md
+++ b/components/input-chip.md
@@ -4,7 +4,7 @@
 
 > **Binding:** By default, Data set with the **Content** field in the **Properties** tab in the plugin will be applied to the *Content* property for this component.
 
-![inputchip](.\images\inputchip.png)
+![inputchip](images/inputchip.png)
 
 | Property  | Options                                           | Description                                                  |
 | --------- | ------------------------------------------------- | ------------------------------------------------------------ |

--- a/components/keyboard.md
+++ b/components/keyboard.md
@@ -2,7 +2,7 @@
 
 > **Note:**  **Keyboard** is only ornamental, it will not affect the plugin at all.
 
-![keyboard](.\images\keyboard.png)
+![keyboard](images/keyboard.png)
 
 | Property | Options          | Description                                              |
 | -------- | ---------------- | -------------------------------------------------------- |

--- a/components/list-item.md
+++ b/components/list-item.md
@@ -4,7 +4,7 @@
 
 
 
-![listitem](.\images\listitem.png)
+![listitem](images/listitem.png)
 
 | Property           | Options             | Description                                                  |
 | ------------------ | ------------------- | ------------------------------------------------------------ |

--- a/components/person-picture.md
+++ b/components/person-picture.md
@@ -2,7 +2,7 @@
 
 > **Binding:** By default, Data set with the **Content** field in the **Properties** tab in the plugin will be applied to the *ProfilePicture* property for this component.
 
-![personpicture](.\images\personpicture.png)
+![personpicture](images/personpicture.png)
 
 | Property | Options               | Description                                                  |
 | -------- | --------------------- | ------------------------------------------------------------ |

--- a/components/progress-bar.md
+++ b/components/progress-bar.md
@@ -2,7 +2,7 @@
 
 > **Note:** Currently the **ProgressBar** is not affected by the **Selection colors** property from Figma. In other words, the **ProgressBar** will always be the same colors in the plugin.
 
-![progressbar](.\images\progressbar.png)
+![progressbar](images/progressbar.png)
 
 | Property | Options                      | Description                                                  |
 | -------- | ---------------------------- | ------------------------------------------------------------ |

--- a/components/progress-ring.md
+++ b/components/progress-ring.md
@@ -2,7 +2,7 @@
 
 > **Note:** Currently the **ProgressRing** is not affected by the **Selection colors** property from Figma. In other words, the **ProgressRing** will always be the same colors in the plugin.
 
-![progressring](.\images\progressring.png)
+![progressring](images/progressring.png)
 
 | Property | Options                      | Description                                                  |
 | -------- | ---------------------------- | ------------------------------------------------------------ |

--- a/components/radio-button.md
+++ b/components/radio-button.md
@@ -1,6 +1,6 @@
 # RadioButton
 
-![radiobutton](.\images\radiobutton.png)
+![radiobutton](images/radiobutton.png)
 
 | Property | Options                                    | Description                                                  |
 | -------- | ------------------------------------------ | ------------------------------------------------------------ |

--- a/components/suggestion-chip.md
+++ b/components/suggestion-chip.md
@@ -4,7 +4,7 @@
 
 > **Binding:** By default, Data set with the **Content** field in the **Properties** tab in the plugin will be applied to the *Content* property for this component.
 
-![suggestionchip](.\images\suggestionchip.png)
+![suggestionchip](images/suggestionchip.png)
 
 | Property | Options                                           | Description                                                  |
 | -------- | ------------------------------------------------- | ------------------------------------------------------------ |

--- a/components/swipe-control.md
+++ b/components/swipe-control.md
@@ -2,7 +2,7 @@
 
 > **Note:** When rendering a **SwipeControl** using the Uno Plugin only the first element of the list will rendered, but the the other elements will still be present. To actually see the swiping in effect while using the plugin, you will need to use a touch screen.
 
-![swipecontrol](.\images\swipecontrol.png)
+![swipecontrol](images/swipecontrol.png)
 
 | Property    | Options                                  | Description                                                  |
 | ----------- | ---------------------------------------- | ------------------------------------------------------------ |

--- a/components/text-block.md
+++ b/components/text-block.md
@@ -6,7 +6,7 @@
 
 
 
-![textblock](.\images\textblock.png)
+![textblock](images/textblock.png)
 
 | Property | Options      | Description                                                  |
 | -------- | ------------ | ------------------------------------------------------------ |

--- a/components/text-box.md
+++ b/components/text-box.md
@@ -4,7 +4,7 @@
 
 > **Binding:** By default, Data set with the **Content** field in the **Properties** tab in the plugin will be applied to the *Text* property for this component.
 
-![textbox](.\images\textbox.png)
+![textbox](images/textbox.png)
 
 | Property     | Options                                          | Description                                                  |
 | ------------ | ------------------------------------------------ | ------------------------------------------------------------ |


### PR DESCRIPTION
How it looks today:
![image](https://user-images.githubusercontent.com/20712372/199869091-4ba7531e-94be-481c-8ceb-15ec969705c7.png)
